### PR TITLE
Fix method get_center_of_mass_and_inertia_matrix() in DQ_CoppeliaSimInterfaceZMQExperimental class

### DIFF
--- a/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQExperimental.cpp
+++ b/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQExperimental.cpp
@@ -1495,9 +1495,8 @@ std::tuple<DQ, MatrixXd> DQ_CoppeliaSimInterfaceZMQExperimental::get_center_of_m
                                                         inertia_matrix_coeff.size()).reshaped(3,3);
     MatrixXd COM_body_frame_matrix =  get_transformation_matrix(center_of_mass_coeff);
     DQ COM_body_frame = DQ(COM_body_frame_matrix.col(3));
-    double mass = get_mass(handle);
 
-    return {COM_body_frame, Inertia_maxtrix_body_frame/mass};
+    return {COM_body_frame, Inertia_maxtrix_body_frame};
 }
 
 /**


### PR DESCRIPTION
Hi @juanjqo,

The method `get_center_of_mass_and_inertia_matrix()` in the class `DQ_CoppeliaSimInterfaceZMQExperimental` was dividing the inertia tensor by the body's mass. I'm unsure what motivated this implementation, but I removed this division. Not only this was misleading, as nothing in the documentation or signature of this method, or the higher level `get_inertia_matrix()`, indicated this operation would be performed, as it contradicts the implementation of the legacy [C++ ](https://github.com/dqrobotics/cpp-interface-vrep/blob/b7517390d48ff6a5ae6feb56d5c1fdadd20ceeae/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp#L1547)and [MATLAB](https://github.com/dqrobotics/matlab/pull/109/files) versions.

I believe it's for the best if users perform the division of the inertia tensor by the mass themselves if required for their application.

Kind regards,
Frederico