### PR TITLE
Fix get_joint_torques() returning torques with inverse sign (issue #9)

### DIFF
--- a/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
+++ b/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
@@ -765,7 +765,7 @@ void DQ_CoppeliaSimInterfaceZMQ::set_joint_torques(const std::vector<std::string
 double DQ_CoppeliaSimInterfaceZMQ::_get_joint_torque(const int &handle) const
 {
     _check_client();
-    return _ZMQWrapper::get_sim()->getJointForce(handle);
+    return -1*_ZMQWrapper::get_sim()->getJointForce(handle);
 }
 
 /**


### PR DESCRIPTION
Fix #9.