### PR TITLE
This PR fixes two bugs in the protected _set_joint_torque and _get_joint_torques of the DQ_CoppeliaSimInterfaceZMQ class

### DIFF
--- a/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
+++ b/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
@@ -707,16 +707,7 @@ void DQ_CoppeliaSimInterfaceZMQ::set_joint_target_velocities(const std::vector<s
 void DQ_CoppeliaSimInterfaceZMQ::_set_joint_torque(const int &handle, const double &torque) const
 {
     _check_client();
-    double angle_dot_rad_max = 10000.0;
-    if (torque==0)
-        angle_dot_rad_max = 0.0;
-    else if (torque<0)
-        angle_dot_rad_max = -10000.0;
-
-    //simxSetJointTargetVelocity(clientid_,handle,angle_dot_rad_max,_remap_op_mode(opmode));
-    //simxSetJointForce(clientid_,handle,abs(torque_f),_remap_op_mode(opmode));
-    _ZMQWrapper::get_sim()->setJointTargetVelocity(handle, angle_dot_rad_max);
-    _ZMQWrapper::get_sim()->setJointTargetForce(handle, abs(torque));
+    _ZMQWrapper::get_sim()->setJointTargetForce(handle, torque, true);
 }
 
 /**
@@ -765,7 +756,7 @@ void DQ_CoppeliaSimInterfaceZMQ::set_joint_torques(const std::vector<std::string
 double DQ_CoppeliaSimInterfaceZMQ::_get_joint_torque(const int &handle) const
 {
     _check_client();
-    return _ZMQWrapper::get_sim()->getJointForce(handle);
+    return -_ZMQWrapper::get_sim()->getJointForce(handle);
 }
 
 /**

--- a/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
+++ b/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
@@ -749,20 +749,36 @@ void DQ_CoppeliaSimInterfaceZMQ::set_joint_torques(const std::vector<std::string
 }
 
 /**
- * @brief DQ_CoppeliaSimInterfaceZMQ::get_joint_torque
- * @param handle
- * @return
+ * @brief DQ_CoppeliaSimInterfaceZMQ::get_joint_torque retrieves the force or torque applied to a joint along/about its active axis.
+ * @param handle the object handle.
+ * @return The force or torque applied to a joint along/about its active axis.
  */
 double DQ_CoppeliaSimInterfaceZMQ::_get_joint_torque(const int &handle) const
 {
     _check_client();
+    /*
+    The getJointForce method retrieves the force or torque applied to a joint along/about its active axis.
+    This method uses the joint perspective, which returns an inverted signal value.
+    For instance, if the joint is set to a positive target force (e.g., using setJointTargetForce),
+    the direction of motion will follow the right-hand rule.
+    However, when using getJointForce, which uses the joint perspective, this motion is seen as clockwise,
+    resulting in a negative value.
+
+    More information:
+                       https://manual.coppeliarobotics.com/en/regularApi/simGetJointForce.htm
+                               https://forum.coppeliarobotics.com/viewtopic.php?p=41694&hilit=getJointForce#p41694
+
+    Therefore, to return a joint force using the same reference that
+    setJointTargetForce uses, we multiply it by -1.
+    */
     return -_ZMQWrapper::get_sim()->getJointForce(handle);
 }
 
 /**
- * @brief DQ_CoppeliaSimInterfaceZMQ::get_joint_torque
- * @param jointname
- * @return
+ * @brief DQ_CoppeliaSimInterfaceZMQ::get_joint_torque retrieves the force or torque applied to a joint
+ *          along/about its active axis.
+ * @param jointname The joint name
+ * @return the force or torque applied to a joint along/about its active axis.
  */
 double DQ_CoppeliaSimInterfaceZMQ::_get_joint_torque(const std::string &jointname)
 {


### PR DESCRIPTION
![](https://img.shields.io/badge/Tests-developer%20workflow-orange)![](https://img.shields.io/badge/Ubuntu%2024.04.5%20LTS%20(x64)-tested-passing)

@dqrobotics/developers 


Hi @mmmarinho,


This PR fixes two bugs in the protected _set_joint_torque and _get_joint_torques methods of the `DQ_CoppeliaSimInterfaceZMQ` class. Specifically, this PR fixes the bug #9. Furthermore,  I fixed a bug in the method _set_joint_torque. This bug consists in that only positive torques are set in the joint. In the legacy API, we used to set always positive torques, in which the desired direction of motion were set by a high signed velocity. This is not working anymore in the ZMQ remote API. Instead, we can now define the desired direction of motion using the sign of the torque using just [simSetJointTargetForce()](https://manual.coppeliarobotics.com/en/regularApi/simSetJointTargetForce.htm)

I tested the modifications using the same example I used in my last Python PR. I opened a [PR](https://github.com/dqrobotics/coppeliasim-scenes) to propose the new scene.

Kind regards, 

Juancho

### Tests

```cpp
#include <iostream>
#include <dqrobotics/DQ.h>
#include <dqrobotics/utils/DQ_Constants.h>
#include <dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h>


using namespace DQ_robotics;
using namespace Eigen;

int main()
{
    auto cs = DQ_CoppeliaSimInterfaceZMQ();

    try{
        // Establishes the connection with CoppeliaSim.
        cs.connect("localhost", 23000, 800);

        // Set the stepping mode.
        // Check more in https://manual.coppeliarobotics.com/en/simulation.htm
        cs.set_stepping_mode(true);

        cs.start_simulation();

        // Define some parameters to compute varying-time trajectories
        double a{1};
        double freq{0.1};
        double time_simulation_step{0.05};

        for (size_t i=0;i<300;i++)
        {
            double t = i*time_simulation_step;

            // Define a varying-time position based on the Lemniscate of Bernoulli
            DQ p = (a*cos(t)/(1 + pow(sin(t),2)))*i_ + (a*sin(t)*cos(t)/(1 + pow(sin(t),2)))*j_;

            // Define a varying-time orientation
            DQ r = cos(2*pi*freq*t) + k_*sin(2*pi*freq*t);

            // Built a varying-time unit dual quaternion
            DQ x = r + 0.5*E_*p*r;

            // Set the object pose in CoppeliaSim
            cs.set_object_pose("/coffee_drone", x);

            // Read the pose of an object in CoppeliaSim to set the pose of
            // another object with a constant offset.
            DQ xread = cs.get_object_pose("/coffee_drone");
            DQ xoffset = 1 + 0.5*E_*(0.5*i_);
            DQ xnew = xread*xoffset;
            cs.set_object_pose("/Frame_x", xnew);


            // Set the target position of the first joint of the UMIRobot arm
            VectorXd target_position = (VectorXd(1) <<sin(2*pi*freq*t)).finished();
            std::vector<std::string> umi_joint = {"UMIRobot/UMIRobot_joint_1"};
            cs.set_joint_target_positions(umi_joint, target_position);

            // Set the target position of the third joint of the UR5 robot
            std::vector<std::string> ur5_joint = {"UR5/link/joint/link/joint"};
            cs.set_joint_target_positions(ur5_joint, target_position);

            // Set the target velocity of the first joint of the Franka Emika Panda
            VectorXd target_velocity = (VectorXd(1) <<2*pi*freq*cos(2*pi*freq*t)).finished();
            std::vector<std::string> franka_joint = {"Franka/joint"};
            cs.set_joint_target_velocities(franka_joint, target_velocity);

            // Set the torque of the Dummy Robot
            VectorXd torque = (VectorXd(1) <<sin(2*pi*freq*t)).finished();
            std::vector<std::string> dummy_joint = {"Revolute_joint"};
            cs.set_joint_torques(dummy_joint, torque);



            // Set the target velocities of the Pioneer wheels
            std::vector<std::string> pioneer_rjoint = {"PioneerP3DX/rightMotor"};
            std::vector<std::string> pioneer_ljoint = {"PioneerP3DX/leftMotor"};
            cs.set_joint_target_velocities(pioneer_rjoint, (VectorXd(1) << 0.1).finished());
            cs.set_joint_target_velocities(pioneer_ljoint, (VectorXd(1) << 0.2).finished());


            // Trigger a simulation step in CoppeliaSim
            cs.trigger_next_simulation_step();

            auto torque_read = cs.get_joint_torques(dummy_joint );
            std::cout<<torque<<"  , "<<torque_read<<std::endl;
        }
        cs.stop_simulation();

    } catch (std::exception& e) {

        std::cout<<e.what()<<std::endl;
        cs.stop_simulation();
    }
}

```

Output:
```shell
[...]
-0.125333  , -0.125333
-0.0941083  , -0.0941083
-0.0627905  , -0.0627905
-0.0314108  , -0.0314108
-2.44929e-16  , -2.44929e-16
0.0314108  , 0.0314108
0.0627905  , 0.0627905
0.0941083  , 0.0941083
0.125333  , 0.125333
0.156434  , 0.156434
[...]
```