### PR TITLE
This PR modifies the behavior of the protected method _throw_runtime_error.

### DIFF
--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2024 DQ Robotics Developers
+(C) Copyright 2011-2025 DQ Robotics Developers
 
 This file is based on DQ Robotics.
 

--- a/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
+++ b/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
@@ -962,7 +962,6 @@ void DQ_CoppeliaSimInterfaceZMQ::_check_client() const
 
 [[noreturn]] void DQ_CoppeliaSimInterfaceZMQ::_throw_runtime_error(const std::string &msg) const
 {
-    stop_simulation();
-    std::cerr<<"Something went wrong. I stopped the simulation!"<<std::endl;
+    std::cerr<<"Something went wrong!"<<std::endl;
     throw std::runtime_error(msg);
 }

--- a/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
+++ b/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2024 DQ Robotics Developers
+(C) Copyright 2011-2025 DQ Robotics Developers
 
 This file is based on DQ Robotics.
 


### PR DESCRIPTION
Hi @mmmarinho,

This PR modifies the behavior of the protected method _throw_runtime_error. Now, this method no longer stops the simulation when called. The current behavior, which I implemented in the first version of the class, is causing some issues in my experiments. I have several nodes communicating with CoppeliaSim. If a problem appears in one of them, it is undesirable to stop the simulation since the other nodes are still sending/receiving data to/from CoppeliaSim. 

Kind regards, 

Juancho