### PR TITLE
This PR adds a new method to get the joint names in a hierarchy tree given the parent object name

### DIFF
--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h
@@ -196,7 +196,7 @@ protected:
 
     std::string _get_object_name(const int& handle);
 
-    template<typename T>
+    template <typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
     std::vector<std::string> _get_object_names(const std::vector<T>& handles)
     {
         int n = handles.size();

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h
@@ -197,7 +197,7 @@ protected:
     std::string _get_object_name(const int& handle);
 
     template<typename T>
-    std::vector<std::string> _get_object_names(const T &handles)
+    std::vector<std::string> _get_object_names(const std::vector<T>& handles)
     {
         int n = handles.size();
         std::vector<std::string> objectnames(n);

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h
@@ -74,18 +74,7 @@ public:
                                const VectorXd& torques) override;
     VectorXd get_joint_torques(const std::vector<std::string>& jointnames) override;
 
-    std::string _get_object_name(const int& handle);
-
-    template<typename T>
-    std::vector<std::string> _get_object_names(const T &handles)
-    {
-        int n = handles.size();
-        std::vector<std::string> objectnames(n);
-        for(auto i=0;i<n;i++)
-            objectnames.at(i)=_get_object_name(handles.at(i));
-
-        return objectnames;
-    }
+    std::vector<std::string> get_jointnames_from_object(const std::string& objectname);
 
     //-----------------------------------------------------------------------------------------------------//
     //-----------Deprecated methods------------------------------------------------------------------------//
@@ -203,6 +192,19 @@ protected:
     {
         if (static_cast<std::size_t>(v1.size()) != static_cast<std::size_t>(v2.size()))
             throw std::runtime_error(error_message);
+    }
+
+    std::string _get_object_name(const int& handle);
+
+    template<typename T>
+    std::vector<std::string> _get_object_names(const T &handles)
+    {
+        int n = handles.size();
+        std::vector<std::string> objectnames(n);
+        for(auto i=0;i<n;i++)
+            objectnames.at(i)=_get_object_name(handles.at(i));
+
+        return objectnames;
     }
 };
 

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h
@@ -185,6 +185,13 @@ protected:
     VectorXd _get_joint_torques(const std::vector<int>& handles) const;
 
 
+    /**
+     * @brief _check_sizes This method throws an exception with a desired message if
+                           the sizes of v1 and v2 are different.
+     * @param v1 The first vector to be compared (Eigen::VectorXd or std::vector<>)
+     * @param v2 The second vector to be compared (Eigen::VectorXd or std::vector<>)
+     * @param error_message The message to be displayed when the exception is raised.
+     */
     template <typename T, typename U>
     void _check_sizes(const T &v1,
                       const U &v2,
@@ -196,6 +203,12 @@ protected:
 
     std::string _get_object_name(const int& handle);
 
+
+    /**
+     * @brief _get_object_names This method gets the object names in the CoppeliaSim scene.
+     * @param handles The object handles.
+     * @return The desired object names.
+     */
     template <typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
     std::vector<std::string> _get_object_names(const std::vector<T>& handles)
     {

--- a/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
+++ b/src/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.cpp
@@ -816,6 +816,22 @@ VectorXd DQ_CoppeliaSimInterfaceZMQ::get_joint_torques(const std::vector<std::st
 }
 
 /**
+ * @brief DQ_CoppeliaSimInterfaceZMQ::get_jointnames_from_object gets all the names of the joints under the hierarchy tree,
+ *                      in which the object name describes its base.
+ * @param objectname The parent object name of the joints.
+ * @return A vector containing the jointnames.
+ */
+std::vector<std::string> DQ_CoppeliaSimInterfaceZMQ::get_jointnames_from_object(const std::string &objectname)
+{
+    _check_client();
+    std::vector<int64_t> jointhandles = _ZMQWrapper::get_sim()->getObjectsInTree(_get_handle_from_map(objectname),
+                                                                                 _ZMQWrapper::get_sim()->object_joint_type,
+                                                                                 0);
+    return _get_object_names(jointhandles);
+}
+
+
+/**
  * @brief DQ_CoppeliaSimInterfaceZMQ::get_object_name gets the name of an object in the CoppeliaSim scene
  * @param handle the object handle.
  * @return The object name


### PR DESCRIPTION
Hi @mmmarinho, 

This PR adds a new method to get the joint names in a hierarchy tree given the parent object name. The method was proposed in https://github.com/dqrobotics/matlab-interface-coppeliasim-zmq/pull/2  (~~**_under review_**~~ **__merged__**). This method is the base for the future `DQ_CoppeliaSimRobotZMQ` class. 

### Minimal example

```cpp
#include <dqrobotics/DQ.h>
#include <dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.h>

int main()
{
    DQ_CoppeliaSimInterfaceZMQ cs{};
    try {
        cs.connect();
        cs.start_simulation();
        auto jointnames = cs.get_jointnames_from_object("/LBR4p");
        for (auto& jointname : jointnames)
            std::cout<<jointname<<std::endl;
        cs.stop_simulation();
    }
    catch (const std::runtime_error& e)
    {
        std::cerr<<e.what()<<std::endl;
    }
}
```

```shell
/LBR4p/joint
/LBR4p/link/joint
/LBR4p/link/joint/link/joint
/LBR4p/link/joint/link/joint/link/joint
/LBR4p/link/joint/link/joint/link/joint/link/joint
/LBR4p/joint/link/joint/link/joint/link/joint/link/joint/link/joint
/LBR4p/joint/link/joint/link/joint/link/joint/link/joint/link/joint/link/joint
```
I proposed an example here https://github.com/dqrobotics/cpp-examples/pull/22

Kind regards, 

Juancho